### PR TITLE
fix: remove redundant code field from MdxApiException

### DIFF
--- a/common/src/main/java/com/mx/path/gateway/util/MdxApiException.java
+++ b/common/src/main/java/com/mx/path/gateway/util/MdxApiException.java
@@ -20,9 +20,6 @@ public class MdxApiException extends PathRequestException {
   private String clientId;
   @Getter
   @Setter
-  private String code;
-  @Getter
-  @Setter
   private String endpointKey;
   @Getter
   @Setter

--- a/common/src/test/groovy/com/mx/path/gateway/util/MdxApiExceptionTest.groovy
+++ b/common/src/test/groovy/com/mx/path/gateway/util/MdxApiExceptionTest.groovy
@@ -1,6 +1,6 @@
 package com.mx.path.gateway.util
 
-
+import com.google.gson.Gson
 import com.mx.common.http.HttpStatus
 
 import spock.lang.Specification
@@ -66,7 +66,18 @@ class MdxApiExceptionTest extends Specification {
     subject.getReason() == null
   }
 
-  def "withReason()" () {
+  def "withCode()"() {
+    given:
+    def subject = new MdxApiException(HttpStatus.OK)
+
+    when:
+    subject.withCode("4001")
+
+    then:
+    subject.getCode() == "4001"
+  }
+
+  def "withReason()"() {
     given:
     def subject = new MdxApiException(HttpStatus.OK)
 
@@ -116,5 +127,22 @@ class MdxApiExceptionTest extends Specification {
 
     then:
     subject.getMessage() == "New message"
+  }
+
+  def "serializes"() {
+    given:
+    def ex = new MdxApiException("message1", "client1", HttpStatus.BAD_REQUEST, "title1", "endpoint1", "errorKey1", true, null)
+
+    when:
+    def json = new Gson().toJson(ex)
+
+    then:
+    verifyAll(json) {
+      contains("message1")
+      contains("client1")
+      contains("title1")
+      contains("endpoint1")
+      contains("errorKey1")
+    }
   }
 }


### PR DESCRIPTION
This addresses serialization issue causing messaging responses to not send.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
